### PR TITLE
v2.0 upgrade (remove 'Abstract' class prefix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ php:
     - 7.3
     - 7.2
     - 7.1
-    - 7.0
 
 before_script:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,8 @@ All notable changes to `queueables` will be documented in this file
 - cut support for php5.6
 - bump min laravel/framework & phpunit versions
 - add QueueableTest for testing AbstractQueueable
+
+
+## 2.0.0 - 2021-04-05
+- refactor `AbstractJob` & `AbstractQueueable` to `Job` & `Queueable`
+- cut support for php7.0

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "laravel/framework": ">=5.5"
     },
     "require-dev": {

--- a/src/Job.php
+++ b/src/Job.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Queueables;
 
-abstract class AbstractJob extends AbstractQueueable
+abstract class Job extends Queueable
 {
     // todo: add chain methods to Job class
 

--- a/src/Queueable.php
+++ b/src/Queueable.php
@@ -11,7 +11,7 @@ use Illuminate\Queue\SerializesModels;
 /**
  * Class Queueable.
  */
-abstract class AbstractQueueable implements ShouldQueue
+abstract class Queueable implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, QueueableTrait, SerializesModels;
 }

--- a/tests/JobTest.php
+++ b/tests/JobTest.php
@@ -2,28 +2,18 @@
 
 namespace Sfneal\Queueables\Tests;
 
-use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\TestCase;
 use Sfneal\Queueables\Tests\Mocks\FirstTestJob;
 use Sfneal\Queueables\Tests\Mocks\SecondTestJob;
+use Sfneal\Queueables\Tests\Traits\CanBeQueued;
 
 class JobTest extends TestCase
 {
-    public function test_jobs_can_be_queued()
+    use CanBeQueued;
+
+    protected function setUp(): void
     {
-        // Enable queue faking
-        Queue::fake();
-
-        // Assert that no jobs were pushed...
-        Queue::assertNothingPushed();
-
-        // Dispatch the first job...
-        Queue::push(FirstTestJob::class);
-
-        // Assert a job was pushed twice...
-        Queue::assertPushed(FirstTestJob::class, 1);
-
-        // Assert a job was not pushed...
-        Queue::assertNotPushed(SecondTestJob::class);
+        $this->firstJob = FirstTestJob::class;
+        $this->secondJob = SecondTestJob::class;
     }
 }

--- a/tests/Mocks/FirstTestJob.php
+++ b/tests/Mocks/FirstTestJob.php
@@ -2,9 +2,9 @@
 
 namespace Sfneal\Queueables\Tests\Mocks;
 
-use Sfneal\Queueables\AbstractJob;
+use Sfneal\Queueables\Job;
 
-class FirstTestJob extends AbstractJob
+class FirstTestJob extends Job
 {
     /**
      * Execute the job.

--- a/tests/Mocks/FirstTestQueueable.php
+++ b/tests/Mocks/FirstTestQueueable.php
@@ -2,9 +2,9 @@
 
 namespace Sfneal\Queueables\Tests\Mocks;
 
-use Sfneal\Queueables\AbstractQueueable;
+use Sfneal\Queueables\Queueable;
 
-class FirstTestQueueable extends AbstractQueueable
+class FirstTestQueueable extends Queueable
 {
     /**
      * Execute the job.

--- a/tests/Mocks/SecondTestJob.php
+++ b/tests/Mocks/SecondTestJob.php
@@ -2,9 +2,9 @@
 
 namespace Sfneal\Queueables\Tests\Mocks;
 
-use Sfneal\Queueables\AbstractJob;
+use Sfneal\Queueables\Job;
 
-class SecondTestJob extends AbstractJob
+class SecondTestJob extends Job
 {
     public function handle()
     {

--- a/tests/Mocks/SecondTestQueueable.php
+++ b/tests/Mocks/SecondTestQueueable.php
@@ -2,9 +2,9 @@
 
 namespace Sfneal\Queueables\Tests\Mocks;
 
-use Sfneal\Queueables\AbstractQueueable;
+use Sfneal\Queueables\Queueable;
 
-class SecondTestQueueable extends AbstractQueueable
+class SecondTestQueueable extends Queueable
 {
     /**
      * Execute the job.

--- a/tests/QueueableTest.php
+++ b/tests/QueueableTest.php
@@ -2,28 +2,18 @@
 
 namespace Sfneal\Queueables\Tests;
 
-use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\TestCase;
 use Sfneal\Queueables\Tests\Mocks\FirstTestQueueable;
 use Sfneal\Queueables\Tests\Mocks\SecondTestQueueable;
+use Sfneal\Queueables\Tests\Traits\CanBeQueued;
 
 class QueueableTest extends TestCase
 {
-    public function test_queueables_can_be_queued()
+    use CanBeQueued;
+
+    protected function setUp(): void
     {
-        // Enable queue faking
-        Queue::fake();
-
-        // Assert that no jobs were pushed...
-        Queue::assertNothingPushed();
-
-        // Dispatch the first job...
-        Queue::push(FirstTestQueueable::class);
-
-        // Assert a job was pushed twice...
-        Queue::assertPushed(FirstTestQueueable::class, 1);
-
-        // Assert a job was not pushed...
-        Queue::assertNotPushed(SecondTestQueueable::class);
+        $this->firstJob = FirstTestQueueable::class;
+        $this->secondJob = SecondTestQueueable::class;
     }
 }

--- a/tests/Traits/CanBeQueued.php
+++ b/tests/Traits/CanBeQueued.php
@@ -1,0 +1,38 @@
+<?php
+
+
+namespace Sfneal\Queueables\Tests\Traits;
+
+
+use Illuminate\Support\Facades\Queue;
+
+trait CanBeQueued
+{
+    /**
+     * @var string
+     */
+    protected $firstJob;
+
+    /**
+     * @var string
+     */
+    protected $secondJob;
+
+    public function test_can_be_queued()
+    {
+        // Enable queue faking
+        Queue::fake();
+
+        // Assert that no jobs were pushed...
+        Queue::assertNothingPushed();
+
+        // Dispatch the first job...
+        Queue::push($this->firstJob);
+
+        // Assert a job was pushed twice...
+        Queue::assertPushed($this->firstJob, 1);
+
+        // Assert a job was not pushed...
+        Queue::assertNotPushed($this->secondJob);
+    }
+}

--- a/tests/Traits/CanBeQueued.php
+++ b/tests/Traits/CanBeQueued.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Queueables\Tests\Traits;
-
 
 use Illuminate\Support\Facades\Queue;
 


### PR DESCRIPTION
 - refactor `AbstractJob` & `AbstractQueueable` to `Job` & `Queueable`
 - cut support for php7.0